### PR TITLE
Rework [release] changelog commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ jobs:
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
+    # Ideally the release pipeline `if` statements would check for the release commit
+    # message, but this is not possible in Travis.
+    # https://github.com/travis-ci/travis-ci/issues/8861#issuecomment-349037474
     - stage: tag-new-release-if-applicable
-      if: branch = master AND type != pull_request
+      if: branch = master AND type != pull_request # see additional conditions in gem_helper
       before_script:
         - openssl aes-256-cbc -K $encrypted_bfd358de8814_key -iv $encrypted_bfd358de8814_iv -in ./ci-helpers/atomic_cache_deploy.enc -out atomic_cache_deploy -d
         - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
@@ -29,9 +32,9 @@ jobs:
         - git config --global user.name "Deploy Bot"
         - git remote add deploy ssh://git@github.com/Ibotta/atomic_cache.git
       script:
-        - ./ci-helpers/gem_helper tag_new_release_if_applicable
+        - ./ci-helpers/gem_helper kickoff_release_pipeline
 
-    - stage: publish-gem
-      if: tag =~ ^v # tags starting with "v" represent releases (as in v0.1.0)
+    - stage: publish-gem-if-applicable
+      if: branch = master AND type != pull_request # see additional conditions in gem_helper
       script:
         - ./ci-helpers/gem_helper publish

--- a/ci-helpers/gem_helper
+++ b/ci-helpers/gem_helper
@@ -10,6 +10,7 @@ require 'rake'
 require 'rubygems'
 
 GEM_NAME = 'atomic_cache'.freeze
+RELEASE_COMMIT_PREFIX = '[release]'.freeze
 
 module AtomicCacheCi
   class GemHelper
@@ -19,13 +20,21 @@ module AtomicCacheCi
       end
     end
 
-    def tag_new_release_if_applicable
+    def kickoff_release_pipeline
+      return if release_commit?
+
       puts('Determining if a new release tag is required...')
 
-      create_new_release if repo_has_newer_version_than_rubygems?
+      create_release_commit if repo_has_newer_version_than_rubygems?
     end
 
-    def publish_to_rubygems
+    def publish
+      return unless release_commit?
+
+      # create a github release first
+      github_release
+
+      # publish to rubygems
       gemfile = gemhelper.build_gem
       Gems.push(File.new(gemfile))
     end
@@ -42,6 +51,10 @@ module AtomicCacheCi
 
     def local_version
       AtomicCache::VERSION
+    end
+
+    def release_commit?
+      ENV['TRAVIS_COMMIT_MESSAGE'].start_with?(RELEASE_COMMIT_PREFIX)
     end
 
     def repo_has_newer_version_than_rubygems?
@@ -72,12 +85,7 @@ module AtomicCacheCi
       version
     end
 
-    def create_new_release
-      update_changelog
-      github_release
-    end
-
-    def update_changelog
+    def create_release_commit
       # generate the changelog
       rake = Rake.application
       rake.init
@@ -90,8 +98,7 @@ module AtomicCacheCi
       git.reset
       git.add('CHANGELOG.md')
 
-      # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-a-build
-      git.commit("[skip ci] release #{local_version}")
+      git.commit("#{RELEASE_COMMIT_PREFIX} #{local_version}")
       git.push('deploy')
     end
 
@@ -115,8 +122,8 @@ end
 
 cmd = ARGV.first
 case cmd
-when 'tag_new_release_if_applicable'
-  AtomicCacheCi::GemHelper.new.tag_new_release_if_applicable
+when 'kickoff_release_pipeline'
+  AtomicCacheCi::GemHelper.new.kickoff_release_pipeline
 when 'publish'
-  AtomicCacheCi::GemHelper.new.publish_to_rubygems
+  AtomicCacheCi::GemHelper.new.publish
 end


### PR DESCRIPTION
To avoid a race condition between publishing the changelog and publishing to rubygems, I originally was using a `[skip-ci]` tag. However because that was the command that was being tagged, my `publish_to_rubygems` logic wasn't running. So, this PR reworks it slightly.

When there is a newer version on master than rubygems, we create the changelog and push it to master with the `[release]` prefix. This commit then kicks off the GitHub release tagging and the push to rubygems.org.