### PR TITLE
Marshaling

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@ibotta.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at osscompliance@ibotta.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at osscompliance@ibotta.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@ibotta.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -37,8 +37,7 @@ module AtomicCache
     # @option options [Numeric] :max_retries (5) Max times to rety in waiting case
     # @option options [Numeric] :backoff_duration_ms (50) Duration in ms to wait between retries
     # @yield Generates a new value when cache is expired
-    def fetch(keyspace, options=nil)
-      options ||= {}
+    def fetch(keyspace, options={})
       key = @timestamp_manager.current_key(keyspace)
       tags = ["cache_keyspace:#{keyspace.root}"]
 

--- a/lib/atomic_cache/key/last_mod_time_key_manager.rb
+++ b/lib/atomic_cache/key/last_mod_time_key_manager.rb
@@ -54,7 +54,7 @@ module AtomicCache
     # @param keyspace [AtomicCache::Keyspace] keyspace to lock
     # @param ttl [Numeric] the duration in ms to lock (auto expires after duration is up)
     # @param options [Hash] options to pass to the storage adapter
-    def lock(keyspace, ttl, options=nil)
+    def lock(keyspace, ttl, options={})
       @storage.add(keyspace.lock_key, LOCK_VALUE, ttl, options)
     end
 

--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -32,13 +32,11 @@ module AtomicCache
       end
 
       def read(key, user_options={})
-        raw = @dalli_client.read(key, user_options)
-        unmarshal(raw, user_options)
+        @dalli_client.read(key, user_options)
       end
 
       def set(key, value, user_options={})
-        marshaled = marshal(value, user_options)
-        @dalli_client.set(key, marshaled, user_options)
+        @dalli_client.set(key, value, user_options)
       end
 
     end

--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -20,8 +20,8 @@ module AtomicCache
         @dalli_client = dalli_client
       end
 
-      def add(key, new_value, ttl, user_options=nil)
-        opts = user_options&.clone || {}
+      def add(key, new_value, ttl, user_options={})
+        opts = user_options.clone
         opts[:raw] = true
 
         # dalli expects time in seconds
@@ -31,14 +31,12 @@ module AtomicCache
         response.start_with?(ADD_SUCCESS)
       end
 
-      def read(key, user_options=nil)
-        user_options ||= {}
+      def read(key, user_options={})
         raw = @dalli_client.read(key, user_options)
         unmarshal(raw, user_options)
       end
 
-      def set(key, value, user_options=nil)
-        user_options ||= {}
+      def set(key, value, user_options={})
         marshaled = marshal(value, user_options)
         @dalli_client.set(key, marshaled, user_options)
       end

--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -33,12 +33,14 @@ module AtomicCache
 
       def read(key, user_options=nil)
         user_options ||= {}
-        @dalli_client.read(key, user_options)
+        raw = @dalli_client.read(key, user_options)
+        unmarshal(raw, user_options)
       end
 
       def set(key, value, user_options=nil)
         user_options ||= {}
-        @dalli_client.set(key, value, user_options)
+        raw = marshal(value, user_options)
+        @dalli_client.set(key, raw, user_options)
       end
 
     end

--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -39,8 +39,8 @@ module AtomicCache
 
       def set(key, value, user_options=nil)
         user_options ||= {}
-        raw = marshal(value, user_options)
-        @dalli_client.set(key, raw, user_options)
+        marshaled = marshal(value, user_options)
+        @dalli_client.set(key, marshaled, user_options)
       end
 
     end

--- a/lib/atomic_cache/storage/instance_memory.rb
+++ b/lib/atomic_cache/storage/instance_memory.rb
@@ -21,14 +21,13 @@ module AtomicCache
         @store
       end
 
-      def store_op(key, user_options=nil)
+      def store_op(key, user_options={})
         if !key.present?
           desc = if key.nil? then 'Nil' else 'Empty' end
           raise ArgumentError.new("#{desc} key given for storage operation") unless key.present?
         end
 
         normalized_key = key.to_sym
-        user_options ||= {}
         yield(normalized_key, user_options)
       end
 

--- a/lib/atomic_cache/storage/memory.rb
+++ b/lib/atomic_cache/storage/memory.rb
@@ -17,7 +17,7 @@ module AtomicCache
       def add(raw_key, new_value, ttl, user_options=nil)
         store_op(raw_key, user_options) do |key, options|
           return false if store.has_key?(key)
-          write(key, new_value, ttl)
+          write(key, new_value, ttl, user_options)
         end
       end
 
@@ -41,7 +41,7 @@ module AtomicCache
 
       def set(raw_key, new_value, user_options=nil)
         store_op(raw_key, user_options) do |key, options|
-          write(key, new_value, options[:expires_in])
+          write(key, new_value, options[:expires_in], user_options)
         end
       end
 
@@ -52,13 +52,9 @@ module AtomicCache
         end
       end
 
-      def write(key, value, ttl=nil)
-        # stored_value = nil
-        # stored_value = Marshal.dump(value) unless value.nil?
-
+      def write(key, value, ttl=nil, user_options=nil)
         store[key] = {
-          # value: stored_value,
-          value: Marshal.dump(value),
+          value: marshal(value, user_options),
           ttl: ttl || false,
           written_at: Time.now
         }

--- a/lib/atomic_cache/storage/memory.rb
+++ b/lib/atomic_cache/storage/memory.rb
@@ -26,7 +26,7 @@ module AtomicCache
           entry = store[key]
           return nil unless entry.present?
 
-          unmarshaled = Marshal.load(entry[:value])
+          unmarshaled = unmarshal(entry[:value], user_options)
           return unmarshaled if entry[:ttl].nil? or entry[:ttl] == false
 
           life = Time.now - entry[:written_at]

--- a/lib/atomic_cache/storage/memory.rb
+++ b/lib/atomic_cache/storage/memory.rb
@@ -12,16 +12,16 @@ module AtomicCache
       def store; raise NotImplementedError end
 
       # @abstract implement performing an operation on the store
-      def store_op(key, user_options=nil); raise NotImplementedError end
+      def store_op(key, user_options={}); raise NotImplementedError end
 
-      def add(raw_key, new_value, ttl, user_options=nil)
+      def add(raw_key, new_value, ttl, user_options={})
         store_op(raw_key, user_options) do |key, options|
           return false if store.has_key?(key)
           write(key, new_value, ttl, user_options)
         end
       end
 
-      def read(raw_key, user_options=nil)
+      def read(raw_key, user_options={})
         store_op(raw_key, user_options) do |key, options|
           entry = store[key]
           return nil unless entry.present?
@@ -39,7 +39,7 @@ module AtomicCache
         end
       end
 
-      def set(raw_key, new_value, user_options=nil)
+      def set(raw_key, new_value, user_options={})
         store_op(raw_key, user_options) do |key, options|
           write(key, new_value, options[:expires_in], user_options)
         end
@@ -52,7 +52,9 @@ module AtomicCache
         end
       end
 
-      def write(key, value, ttl=nil, user_options=nil)
+      protected
+
+      def write(key, value, ttl=nil, user_options)
         store[key] = {
           value: marshal(value, user_options),
           ttl: ttl || false,

--- a/lib/atomic_cache/storage/memory.rb
+++ b/lib/atomic_cache/storage/memory.rb
@@ -26,14 +26,15 @@ module AtomicCache
           entry = store[key]
           return nil unless entry.present?
 
-          return entry[:value] if entry[:ttl].nil? or entry[:ttl] == false
+          unmarshaled = Marshal.load(entry[:value])
+          return unmarshaled if entry[:ttl].nil? or entry[:ttl] == false
 
           life = Time.now - entry[:written_at]
           if (life >= entry[:ttl])
             store.delete(key)
             nil
           else
-            entry[:value]
+            unmarshaled
           end
         end
       end
@@ -52,11 +53,12 @@ module AtomicCache
       end
 
       def write(key, value, ttl=nil)
-        stored_value = value.to_s
-        stored_value = nil if value.nil?
+        # stored_value = nil
+        # stored_value = Marshal.dump(value) unless value.nil?
 
         store[key] = {
-          value: stored_value,
+          # value: stored_value,
+          value: Marshal.dump(value),
           ttl: ttl || false,
           written_at: Time.now
         }

--- a/lib/atomic_cache/storage/shared_memory.rb
+++ b/lib/atomic_cache/storage/shared_memory.rb
@@ -26,10 +26,8 @@ module AtomicCache
         STORE
       end
 
-      def store_op(key, user_options=nil)
+      def store_op(key, user_options={})
         normalized_key = key.to_sym
-        user_options ||= {}
-
         SEMAPHORE.synchronize do
           yield(normalized_key, user_options)
         end

--- a/lib/atomic_cache/storage/store.rb
+++ b/lib/atomic_cache/storage/store.rb
@@ -26,6 +26,24 @@ module AtomicCache
       # returns true if it succeeds; false otherwise
       def delete(key, user_options); raise NotImplementedError end
 
+      protected
+
+      def marshal(value, user_options=nil)
+        if !user_options.nil? && user_options[:raw]
+          value
+        else
+          Marshal.dump(value)
+        end
+      end
+
+      def unmarshal(value, user_options=nil)
+        if !user_options.nil? && user_options[:raw]
+          value
+        else
+          Marshal.load(value)
+        end
+      end
+
     end
   end
 end

--- a/lib/atomic_cache/storage/store.rb
+++ b/lib/atomic_cache/storage/store.rb
@@ -28,22 +28,14 @@ module AtomicCache
 
       protected
 
-      def marshal(value, user_options)
-        user_options ||= {}
-        if user_options[:raw]
-          value
-        else
-          Marshal.dump(value)
-        end
+      def marshal(value, user_options={})
+        return value if user_options[:raw]
+        Marshal.dump(value)
       end
 
-      def unmarshal(value, user_options)
-        user_options ||= {}
-        if user_options[:raw]
-          value
-        else
-          Marshal.load(value)
-        end
+      def unmarshal(value, user_options={})
+        return value if user_options[:raw]
+        Marshal.load(value)
       end
 
     end

--- a/lib/atomic_cache/storage/store.rb
+++ b/lib/atomic_cache/storage/store.rb
@@ -28,16 +28,18 @@ module AtomicCache
 
       protected
 
-      def marshal(value, user_options=nil)
-        if !user_options.nil? && user_options[:raw]
+      def marshal(value, user_options)
+        user_options ||= {}
+        if user_options[:raw]
           value
         else
           Marshal.dump(value)
         end
       end
 
-      def unmarshal(value, user_options=nil)
-        if !user_options.nil? && user_options[:raw]
+      def unmarshal(value, user_options)
+        user_options ||= {}
+        if user_options[:raw]
           value
         else
           Marshal.load(value)

--- a/spec/atomic_cache/atomic_cache_client_spec.rb
+++ b/spec/atomic_cache/atomic_cache_client_spec.rb
@@ -86,7 +86,7 @@ describe 'AtomicCacheClient' do
             Timecop.freeze(time) do
               subject.fetch(keyspace) { 'value from block' }
               lmt = key_storage.read(timestamp_manager.last_modified_time_key)
-              expect(lmt).to eq(time.to_i.to_s)
+              expect(lmt).to eq(time.to_i)
             end
           end
 

--- a/spec/atomic_cache/concerns/global_lmt_cache_concern_spec.rb
+++ b/spec/atomic_cache/concerns/global_lmt_cache_concern_spec.rb
@@ -44,7 +44,7 @@ describe 'AtomicCacheConcern' do
       time = Time.local(2018, 1, 1, 15, 30, 0)
       subject.expire_cache(time)
       expect(key_storage.store).to have_key(:'foo1:lmt')
-      expect(key_storage.store[:'foo1:lmt'][:value]).to eq(time.to_i.to_s)
+      expect(key_storage.read(:'foo1:lmt')).to eq(time.to_i)
     end
 
     it 'expires all the keyspaces for this class' do

--- a/spec/atomic_cache/key/last_mod_time_key_manager_spec.rb
+++ b/spec/atomic_cache/key/last_mod_time_key_manager_spec.rb
@@ -42,22 +42,22 @@ describe 'LastModTimeKeyManager' do
 
   it 'promotes a timestamp and last known key' do
     subject.promote(req_keyspace, last_known_key: 'asdf', timestamp: timestamp)
-    expect(storage.store[:'ns:lkk'][:value]).to eq('asdf')
-    expect(storage.store[:'ts:lmt'][:value]).to eq(timestamp.to_s)
-    expect(subject.last_modified_time).to eq(timestamp.to_s)
+    expect(storage.read(:'ns:lkk')).to eq('asdf')
+    expect(storage.read(:'ts:lmt')).to eq(timestamp)
+    expect(subject.last_modified_time).to eq(timestamp)
   end
 
   context '#last_modified_time=' do
     it 'returns the last modified time' do
       subject.last_modified_time = timestamp
-      expect(storage.store[:'ts:lmt'][:value]).to eq(timestamp.to_s)
-      expect(subject.last_modified_time).to eq(timestamp.to_s)
+      expect(storage.read(:'ts:lmt')).to eq(timestamp)
+      expect(subject.last_modified_time).to eq(timestamp)
     end
 
     it 'formats Time' do
       now = Time.now
       subject.last_modified_time = now
-      expect(subject.last_modified_time).to eq(now.to_i.to_s)
+      expect(subject.last_modified_time).to eq(now.to_i)
     end
   end
 

--- a/spec/atomic_cache/storage/dalli_spec.rb
+++ b/spec/atomic_cache/storage/dalli_spec.rb
@@ -14,13 +14,12 @@ describe 'Dalli' do
   subject { AtomicCache::Storage::Dalli.new(dalli_client) }
 
   it 'delegates #set without options' do
-    raw = Marshal.dump('value')
-    expect(dalli_client).to receive(:set).with('key', raw, {})
+    expect(dalli_client).to receive(:set).with('key', 'value', {})
     subject.set('key', 'value')
   end
 
   it 'delegates #read without options' do
-    expect(dalli_client).to receive(:read).with('key', {}).and_return(Marshal.dump('asdf'))
+    expect(dalli_client).to receive(:read).with('key', {}).and_return('asdf')
     subject.read('key')
   end
 

--- a/spec/atomic_cache/storage/dalli_spec.rb
+++ b/spec/atomic_cache/storage/dalli_spec.rb
@@ -14,12 +14,13 @@ describe 'Dalli' do
   subject { AtomicCache::Storage::Dalli.new(dalli_client) }
 
   it 'delegates #set without options' do
-    expect(dalli_client).to receive(:set).with('key', 'value', {})
+    raw = Marshal.dump('value')
+    expect(dalli_client).to receive(:set).with('key', raw, {})
     subject.set('key', 'value')
   end
 
   it 'delegates #read without options' do
-    expect(dalli_client).to receive(:read).with('key', {})
+    expect(dalli_client).to receive(:read).with('key', {}).and_return(Marshal.dump('asdf'))
     subject.read('key')
   end
 

--- a/spec/atomic_cache/storage/memory_spec.rb
+++ b/spec/atomic_cache/storage/memory_spec.rb
@@ -12,13 +12,13 @@ shared_examples 'memory storage' do
       result = subject.add('key', 'value', 100)
 
       expect(subject.store).to have_key(:key)
-      expect(subject.store[:key][:value]).to eq('value')
+      expect(Marshal.load(subject.store[:key][:value])).to eq('value')
       expect(subject.store[:key][:ttl]).to eq(100)
       expect(result).to eq(true)
     end
 
     it 'does not write the key if it exists' do
-      entry = { value: 'foo', ttl: 100, written_at: 100 }
+      entry = { value: Marshal.dump('foo'), ttl: 100, written_at: 100 }
       subject.store[:key] = entry
 
       result = subject.add('key', 'value', 200)
@@ -26,20 +26,36 @@ shared_examples 'memory storage' do
 
       # stored values should not have changed
       expect(subject.store).to have_key(:key)
-      expect(subject.store[:key][:value]).to eq('foo')
+      expect(Marshal.load(subject.store[:key][:value])).to eq('foo')
       expect(subject.store[:key][:ttl]).to eq(100)
     end
   end
 
   context '#read' do
     it 'returns values' do
-      subject.store[:sugar] = { value: 'foo' }
+      subject.store[:sugar] = { value: Marshal.dump('foo') }
       expect(subject.read('sugar')).to eq('foo')
     end
 
     it 'respects TTL' do
-      subject.store[:sugar] = { value: 'foo', ttl: 100, written_at: Time.now - 1000 }
+      subject.store[:sugar] = { value: Marshal.dump('foo'), ttl: 100, written_at: Time.now - 1000 }
       expect(subject.read('sugar')).to eq(nil)
+    end
+
+    it 'returns complex objects' do
+      class ComplexObject
+        attr_accessor :foo, :bar
+      end
+
+      obj = ComplexObject.new
+      obj.foo = 'f'
+      obj.bar = [1,2,3]
+
+      subject.set(:complex, obj)
+
+      obj2 = subject.read(:complex)
+      expect(obj2.foo).to eql('f')
+      expect(obj2.bar).to eql([1,2,3])
     end
   end
 
@@ -47,7 +63,7 @@ shared_examples 'memory storage' do
     it 'adds the value when not present' do
       subject.set(:cane, 'v', expires_in: 100)
       expect(subject.store).to have_key(:cane)
-      expect(subject.store[:cane][:value]).to eq('v')
+      expect(Marshal.load(subject.store[:cane][:value])).to eq('v')
       expect(subject.store[:cane][:ttl]).to eq(100)
     end
 
@@ -56,14 +72,14 @@ shared_examples 'memory storage' do
 
       subject.set(:cane, 'v', expires_in: 100)
       expect(subject.store).to have_key(:cane)
-      expect(subject.store[:cane][:value]).to eq('v')
+      expect(Marshal.load(subject.store[:cane][:value])).to eq('v')
       expect(subject.store[:cane][:ttl]).to eq(100)
     end
   end
 
   context '#delete' do
     it 'deletes the key' do
-      subject.store[:record] = { value: 'foo', written_at: 500 }
+      subject.store[:record] = { value: Marshal.dump('foo'), written_at: 500 }
       subject.delete('record')
       expect(subject.store).to_not have_key(:record)
     end


### PR DESCRIPTION
Adds support for marshaling/unmarshaling complex objects into and out of cache.  This elevates behavior to be in parity with `Rails.cache.fetch` which is automatically handling this.

As far as I can tell, marshaling/unmarshaling seems to be implemented per storage adapter in ActiveSupport ([example](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/mem_cache_store.rb#L194)).  Ruby's `Marshal` seems to be the canonical answer.

Along similar lines, I noticed that compression is being implemented in the same fashion, so it may be necessary to provide compression support manually as well.  There doesn't seem to be a common concern among the ActiveSupport cache implementations that just provides compression and marshaling across the board.