### PR TITLE
Bug: Properly interface with Dalli client

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,6 +21,14 @@ end
 
 In addition to the below options, any other options given (e.g. `expires_in`, `cache_nils`) are passed through to the underlying storage adapter.  This allows storage-specific options to be passed through (reference: [Dalli config](https://github.com/petergoldstein/dalli#configuration)).
 
+#### TTL
+Various storage clients require TTL to be expressed in different ways. The included storage adapters will unwrap the `ttl` option to an storage-specific representation.
+```ruby
+atomic_cache.fetch(ttl: 500) do
+  # generate block
+end
+```
+
 #### `generate_ttl_ms`
 _Defaults to 30 seconds._
 

--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -36,7 +36,9 @@ module AtomicCache
       end
 
       def set(key, value, user_options={})
-        @dalli_client.set(key, value, user_options[:ttl], user_options)
+        ttl = user_options[:ttl]
+        user_options.delete(:ttl)
+        @dalli_client.set(key, value, ttl, user_options)
       end
 
     end

--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -32,11 +32,11 @@ module AtomicCache
       end
 
       def read(key, user_options={})
-        @dalli_client.read(key, user_options)
+        @dalli_client.get(key, user_options)
       end
 
       def set(key, value, user_options={})
-        @dalli_client.set(key, value, user_options)
+        @dalli_client.set(key, value, user_options[:ttl], user_options)
       end
 
     end

--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "0.2.1.rc2"
+  VERSION = "0.2.2.rc1"
 end

--- a/spec/atomic_cache/storage/dalli_spec.rb
+++ b/spec/atomic_cache/storage/dalli_spec.rb
@@ -13,13 +13,20 @@ describe 'Dalli' do
   let(:dalli_client) { FakeDalli.new }
   subject { AtomicCache::Storage::Dalli.new(dalli_client) }
 
-  it 'delegates #set without options' do
-    expect(dalli_client).to receive(:set).with('key', 'value', {})
-    subject.set('key', 'value')
+  context '#set' do
+    it 'delegates #set without options' do
+      expect(dalli_client).to receive(:set).with('key', 'value', nil, {})
+      subject.set('key', 'value')
+    end
+
+    it 'delegates #set with TTL' do
+      expect(dalli_client).to receive(:set).with('key', 'value', 500, {})
+      subject.set('key', 'value', { ttl: 500 })
+    end
   end
 
   it 'delegates #read without options' do
-    expect(dalli_client).to receive(:read).with('key', {}).and_return('asdf')
+    expect(dalli_client).to receive(:get).with('key', {}).and_return('asdf')
     subject.read('key')
   end
 


### PR DESCRIPTION
Background
-----

The Dalli storage adapter appears to incorrectly assume the adapter is `Rails.cache` instead of the actual Dalli client. This PR changes it to expect the Dalli client.

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [ ] Backwards-incompatible changes called out in this PR
* [x] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
