### PR TITLE
BUG: Dalli Client response codes

### DIFF
--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -33,7 +33,7 @@ module AtomicCache
       def set(key, value, user_options={})
         ttl = user_options[:ttl]
         user_options.delete(:ttl)
-        @dalli_client.set(key, value, ttl, user_options)
+        !!@dalli_client.set(key, value, ttl, user_options)
       end
 
     end

--- a/lib/atomic_cache/storage/dalli.rb
+++ b/lib/atomic_cache/storage/dalli.rb
@@ -10,10 +10,6 @@ module AtomicCache
     class Dalli < Store
       extend Forwardable
 
-      ADD_SUCCESS = 'STORED'
-      ADD_UNSUCCESSFUL = 'NOT_STORED'
-      ADD_EXISTS = 'EXISTS'
-
       def_delegators :@dalli_client, :delete
 
       def initialize(dalli_client)
@@ -27,8 +23,7 @@ module AtomicCache
         # dalli expects time in seconds
         # https://github.com/petergoldstein/dalli/blob/b8f4afe165fb3e07294c36fb1c63901b0ed9ce10/lib/dalli/client.rb#L27
         # TODO: verify this unit is being treated correctly through the system
-        response = @dalli_client.add(key, new_value, ttl, opts)
-        response.start_with?(ADD_SUCCESS)
+        !!@dalli_client.add(key, new_value, ttl, opts)
       end
 
       def read(key, user_options={})

--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "0.2.2.rc1"
+  VERSION = "0.2.3.rc1"
 end

--- a/spec/atomic_cache/storage/dalli_spec.rb
+++ b/spec/atomic_cache/storage/dalli_spec.rb
@@ -37,7 +37,7 @@ describe 'Dalli' do
 
   context '#add' do
     before(:each) do
-      allow(dalli_client).to receive(:add).and_return('NOT_STORED\r\n')
+      allow(dalli_client).to receive(:add).and_return(false)
     end
 
     it 'delegates to #add with the raw option set' do
@@ -47,22 +47,17 @@ describe 'Dalli' do
     end
 
     it 'returns true when the add is successful' do
-      expect(dalli_client).to receive(:add).and_return('STORED\r\n')
+      expect(dalli_client).to receive(:add).and_return(12339031748204560384)
       result = subject.add('key', 'value', 100)
       expect(result).to eq(true)
     end
 
     it 'returns false if the key already exists' do
-      expect(dalli_client).to receive(:add).and_return('EXISTS\r\n')
+      expect(dalli_client).to receive(:add).and_return(false)
       result = subject.add('key', 'value', 100)
       expect(result).to eq(false)
     end
 
-    it 'returns false if the add fails' do
-      expect(dalli_client).to receive(:add).and_return('NOT_STORED\r\n')
-      result = subject.add('key', 'value', 100)
-      expect(result).to eq(false)
-    end
   end
 
 end


### PR DESCRIPTION
Background
-----

Previous Dalli client was expecting a string response. Updated to expect truthy or falsey values.

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [x] Backwards-incompatible changes called out in this PR
* [x] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
