### PR TITLE
BUG: Waiting on wrong key

### DIFF
--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -59,7 +59,7 @@ module AtomicCache
 
       # quick check back to see if the other process has finished
       # or fall back to the last known value
-      value = quick_retry(keyspace, options, tags) || last_known_value(keyspace, options, tags)
+      value = quick_retry(key, options, tags) || last_known_value(keyspace, options, tags)
       return value if value.present?
 
       # wait for the other process if a last known value isn't there
@@ -109,10 +109,8 @@ module AtomicCache
       nil
     end
 
-    def quick_retry(keyspace, options, tags)
-      key = @timestamp_manager.current_key(keyspace)
+    def quick_retry(key, options, tags)
       duration = option(:quick_retry_ms, options, DEFAULT_quick_retry_ms)
-
       if duration.present? and key.present?
         sleep(duration.to_f / 1000)
         value = @storage.read(key, options)

--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -171,7 +171,7 @@ module AtomicCache
       end
 
       metrics(:increment, 'wait.give-up')
-      log(:warn, "Giving up fetching cache key `#{key}`. Exceeded max retries (#{max_retries}).")
+      log(:warn, "Giving up waiting. Exceeded max retries (#{max_retries}).")
       nil
     end
 

--- a/spec/atomic_cache/integration/waiting_spec.rb
+++ b/spec/atomic_cache/integration/waiting_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Integration' do
+  let(:key_storage) { AtomicCache::Storage::SharedMemory.new }
+  let(:cache_storage) { AtomicCache::Storage::SharedMemory.new }
+  let(:keyspace) { AtomicCache::Keyspace.new(namespace: 'int.waiting') }
+  let(:timestamp_manager) { AtomicCache::LastModTimeKeyManager.new(keyspace: keyspace, storage: key_storage) }
+
+  let(:generating_client) { AtomicCache::AtomicCacheClient.new(storage: cache_storage, timestamp_manager: timestamp_manager) }
+  let(:waiting_client) { AtomicCache::AtomicCacheClient.new(storage: cache_storage, timestamp_manager: timestamp_manager) }
+
+  it 'correctly waits for a key when no last know value is available' do
+    generating_thread = ClientThread.new(generating_client, keyspace)
+    generating_thread.start
+    waiting_thread = ClientThread.new(waiting_client, keyspace)
+    waiting_thread.start
+
+    generating_thread.generate
+    sleep 0.05
+    waiting_thread.fetch
+    sleep 0.05
+    generating_thread.complete
+    sleep 0.05
+
+    generating_thread.terminate
+    waiting_thread.terminate
+
+    expect(generating_thread.result).to eq([1, 2, 3])
+    expect(waiting_thread.result).to eq([1, 2, 3])
+  end
+end
+
+
+# Avert your eyes:
+# this class allows atomic client interaction to happen asynchronously so that
+# the waiting behavior of the client can be tested simultaneous to controlling how
+# long the 'generate' behavior takes
+#
+# It works by accepting an incoming 'message' which it places onto one of two queues
+class ClientThread
+  attr_reader :result
+
+  def initialize(client, keyspace)
+    @keyspace = keyspace
+    @client = client
+    @msg_queue = Queue.new
+    @generate_queue = Queue.new
+    @result = nil
+  end
+
+  def start
+    @thread = Thread.new(&method(:run))
+  end
+
+  def fetch
+    @msg_queue << :fetch
+  end
+
+  def generate
+    @msg_queue << :generate
+  end
+
+  def complete
+    @generate_queue << :complete
+  end
+
+  def terminate
+    @msg_queue << :terminate
+  end
+
+  private
+
+  def run
+    loop do
+      msg = @msg_queue.pop
+      sleep 0.001; next unless msg
+
+      case msg
+      when :terminate
+        Thread.stop
+      when :generate
+        do_generate
+      when :fetch
+        @result = @client.fetch(@keyspace)
+      end
+    end
+  end
+
+  def do_generate
+    @client.fetch(@keyspace) do
+      loop do
+        msg = @generate_queue.pop
+        sleep 0.001; next unless msg
+        break if msg == :complete
+      end
+      @result = [1, 2, 3] # generated value
+      @result
+    end
+  end
+end


### PR DESCRIPTION
Background
-----

A bug was identified earlier today where the `wait_for_new_value` method is incorrectly waiting on the wrong key. This bugfix updates the code to re-fetch the latest key value whenever it attempts to see if another thread has written the value. This makes sure that re-attempts are always attempting to get the latest value.

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [x] Backwards-incompatible changes called out in this PR
* [ ] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
