### PR TITLE
Rename cache_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In a nutshell:
 class Foo < ActiveRecord::Base
   include AtomicCache::GlobalLMTCacheConcern
 
-  cache_class(:custom_foo)  # optional
+  force_cache_class(:custom_foo)  # optional
   cache_version(5)          # optional
 
   def active_foos(ids)

--- a/docs/MODEL_SETUP.md
+++ b/docs/MODEL_SETUP.md
@@ -7,13 +7,13 @@ class Foo < ActiveRecord::Base
 end
 ```
 
-### cache_class
+### force_cache_class
 By default the cache identifier for a class is set to the name of a class (ie. `self.to_s`).  In some cases it makes sense to set a custom value for the cache identifier.  In cases where a custom cache identifier is set, it's important that the identifier remain unique across the project.
 
 ```ruby
 class SuperDescriptiveDomainModelAbstractFactoryImplManager < ActiveRecord::Base
   include AtomicCache::GlobalLMTCacheConcern
-  cache_class('sddmafim')
+  force_cache_class('sddmafim')
 end
 ```
 

--- a/lib/atomic_cache/concerns/global_lmt_cache_concern.rb
+++ b/lib/atomic_cache/concerns/global_lmt_cache_concern.rb
@@ -26,7 +26,7 @@ module AtomicCache
         end
       end
 
-      def cache_class(kls)
+      def force_cache_class(kls)
         ATOMIC_CACHE_CONCERN_MUTEX.synchronize do
           @atomic_cache_class = kls
         end

--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "1.0.0.rc1"
+  VERSION = "0.3.0.rc1"
 end

--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "0.2.5.rc1"
+  VERSION = "1.0.0.rc1"
 end

--- a/spec/atomic_cache/concerns/global_lmt_cache_concern_spec.rb
+++ b/spec/atomic_cache/concerns/global_lmt_cache_concern_spec.rb
@@ -104,12 +104,12 @@ describe 'AtomicCacheConcern' do
       class Foo2
         include AtomicCache::GlobalLMTCacheConcern
         cache_version(3)
-        cache_class('foo')
+        force_cache_class('foo')
       end
       Foo2
     end
 
-    it 'uses the given version and cache_class become part of the cache keyspace' do
+    it 'uses the given version and force_cache_class become part of the cache keyspace' do
       subject.expire_cache
       expect(key_storage.store).to have_key(:'foo:v3:lmt')
     end


### PR DESCRIPTION
Background
-----

Rename `cache_class` to `force_cache_class` to more clearly state intent

Version
----
Major Version

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [x] Backwards-incompatible changes called out in this PR
* [x] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
