### PR TITLE
BUG: Correctly handle MemoryStorage#add

### DIFF
--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "0.4.0.rc1"
+  VERSION = "0.4.1.rc1"
 end

--- a/spec/atomic_cache/storage/shared_memory_spec.rb
+++ b/spec/atomic_cache/storage/shared_memory_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require_relative 'memory_spec'
 
-describe 'InstanceMemory' do
+describe 'SharedMemory' do
   subject { AtomicCache::Storage::SharedMemory.new }
   it_behaves_like 'memory storage'
 end


### PR DESCRIPTION
Background
-----

When using `SharedMemory` or `InstanceMemory`, when `add` is called, it should add the key if one does not exist. When one exists, it should still add it if the key has expired. The gem was not doing this second behavior. This PR fixes that.

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [x] Backwards-incompatible changes called out in this PR
* [x] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
