### PR TITLE
Feature: Disable TTL in SharedMemory

### DIFF
--- a/lib/atomic_cache/storage/shared_memory.rb
+++ b/lib/atomic_cache/storage/shared_memory.rb
@@ -10,6 +10,21 @@ module AtomicCache
       STORE = {}
       SEMAPHORE = Mutex.new
 
+      @enforce_ttl = true
+      class << self
+        attr_accessor :enforce_ttl
+      end
+
+      def add(raw_key, new_value, ttl, user_options={})
+        if self.class.enforce_ttl
+          super(raw_key, new_value, ttl, user_options)
+        else
+          store_op(raw_key, user_options) do |key, options|
+            write(key, new_value, ttl, user_options)
+          end
+        end
+      end
+
       def self.reset
         STORE.clear
       end

--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "0.4.1.rc1"
+  VERSION = "0.5.0.rc1"
 end

--- a/spec/atomic_cache/storage/memory_spec.rb
+++ b/spec/atomic_cache/storage/memory_spec.rb
@@ -17,8 +17,6 @@ shared_examples 'memory storage' do
       expect(result).to eq(true)
     end
 
-    # SharedMemory.new.add("foo", ttl: 100)
-
     it 'does not write the key if it exists but expiration time is NOT up' do
       entry = { value: Marshal.dump('foo'), ttl: 5000, written_at: Time.local(2021, 1, 1, 12, 0, 0) }
       subject.store[:key] = entry

--- a/spec/atomic_cache/storage/shared_memory_spec.rb
+++ b/spec/atomic_cache/storage/shared_memory_spec.rb
@@ -6,4 +6,18 @@ require_relative 'memory_spec'
 describe 'SharedMemory' do
   subject { AtomicCache::Storage::SharedMemory.new }
   it_behaves_like 'memory storage'
+
+  context 'enforce_ttl disabled' do
+    before(:each) do
+      AtomicCache::Storage::SharedMemory.enforce_ttl = false
+    end
+
+    it 'allows instantly `add`ing keys' do
+      subject.add("foo", 1, ttl: 100000)
+      subject.add("foo", 2, ttl: 1)
+
+      expect(subject.store).to have_key(:foo)
+      expect(Marshal.load(subject.store[:foo][:value])).to eq(2)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,4 +17,8 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
     expectations.syntax = :expect
   end
+
+  config.before(:each) do
+    AtomicCache::Storage::SharedMemory.enforce_ttl = true
+  end
 end


### PR DESCRIPTION
Background
-----

The README updates cover a lot of the rational about why this change was made. The short version is, this PR adds an `enable_ttl` setting to `SharedMemory` to allow TTL enforcement to be disabled in a testing context, as time doesn't quite pass the same way it does in a production environment.

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [ ] Backwards-incompatible changes called out in this PR
* [x] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
