### PR TITLE
Clearer metrics Without LKK Delete

### DIFF
--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -119,13 +119,11 @@ module AtomicCache
           return lkv
         end
 
-        # if the value of the last known key is nil, we can infer that it's
-        # most likely expired, thus remove it so other processes don't waste
-        # time trying to read it
-        @storage.delete(lkk)
+        metrics(:increment, 'last-known-value.nil', tags: tags)
+      else
+        metrics(:increment, 'last-known-value.not-present', tags: tags)
       end
 
-      metrics(:increment, 'last-known-value.not-present', tags: tags)
       nil
     end
 

--- a/lib/atomic_cache/key/last_mod_time_key_manager.rb
+++ b/lib/atomic_cache/key/last_mod_time_key_manager.rb
@@ -59,6 +59,13 @@ module AtomicCache
       @storage.add(keyspace.lock_key, LOCK_VALUE, ttl, options)
     end
 
+    # check if the keyspace is locked
+    #
+    # @param keyspace [AtomicCache::Keyspace] keyspace to lock
+    def lock_present?(keyspace)
+      @storage.read(keyspace.lock_key) == LOCK_VALUE
+    end
+
     # remove existing lock to allow other processes to update keyspace
     #
     # @param keyspace [AtomicCache::Keyspace] keyspace to lock

--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "0.5.0.rc1"
+  VERSION = "0.5.1.rc1"
 end

--- a/spec/atomic_cache/atomic_cache_client_spec.rb
+++ b/spec/atomic_cache/atomic_cache_client_spec.rb
@@ -168,13 +168,6 @@ describe 'AtomicCacheClient' do
               result = subject.fetch(keyspace, backoff_duration_ms: 5) { 'value from generate' }
               expect(result).to eq(nil)
             end
-
-            it 'deletes the last known key' do
-              key_storage.set(keyspace.last_known_key_key, :oldkey)
-              cache_storage.set(:oldkey, nil)
-              subject.fetch(keyspace, backoff_duration_ms: 5) { 'value from generate' }
-              expect(cache_storage.store).to_not have_key(:oldkey)
-            end
           end
         end
       end

--- a/spec/atomic_cache/key/last_mod_time_key_manager_spec.rb
+++ b/spec/atomic_cache/key/last_mod_time_key_manager_spec.rb
@@ -40,6 +40,15 @@ describe 'LastModTimeKeyManager' do
     expect(storage.store).to_not have_key(:'ns:lock')
   end
 
+  it 'checks if the lock is present' do
+    subject.lock(req_keyspace, 100)
+    expect(subject.lock_present?(req_keyspace)).to eq(true)
+  end
+
+  it 'checks if the lock is not present' do
+    expect(subject.lock_present?(req_keyspace)).to eq(false)
+  end
+
   it 'promotes a timestamp and last known key' do
     subject.promote(req_keyspace, last_known_key: 'asdf', timestamp: timestamp)
     expect(storage.read(:'ns:lkk')).to eq('asdf')


### PR DESCRIPTION
Background
-----

  * Makes the branching for last_known_value fallback clearer
  * Removes deletion of the last known value, until this can be confirmed to be safe

Tasks
-----
* [ ] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [ ] Specs written and passing
* [ ] Backwards-incompatible changes called out in this PR
* [ ] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
