### PR TITLE
Build Matrix: Rails 6, 6.1, Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,11 @@ after_script:
   - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
 
 jobs:
-  exclude:
+  exclude: # matrix variations skipped
     - rvm: 2.5
       gemfile: Gemfile.rails6
+    - rvm: 2.5
+      gemfile: Gemfile.rails61
     - rvm: 2.7
       gemfile: Gemfile.rails52
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: ruby
 addons:
   ssh_known_hosts: github.com
+
 jobs:
   include:
   - stage: test-2.5
     rvm: 2.5
-    script:
-    - bundle exec rake spec
+    gemfile: Gemfile
+    script: bundle exec rake spec
+
   - stage: test-2.6
     rvm: 2.6
+    gemfile: Gemfile
     before_script:
     - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
       > ./cc-test-reporter
@@ -18,6 +21,12 @@ jobs:
     - bundle exec rake spec
     after_script:
     - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+
+  - stage: test-rails6
+    rvm: 2.6
+    gemfile: Gemfile.rails6
+    script: bundle exec rake spec
+
   - stage: tag-new-release-if-applicable
     if: branch = main AND type != pull_request
     rvm: 2.6
@@ -31,6 +40,7 @@ jobs:
     - git remote add deploy ssh://git@github.com/Ibotta/atomic_cache.git
     script:
     - "./ci-helpers/gem_helper kickoff_release_pipeline"
+
   - stage: publish-gem-if-applicable
     if: branch = main AND type != pull_request
     rvm: 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,31 +2,27 @@ language: ruby
 addons:
   ssh_known_hosts: github.com
 
+rvm:
+  - 2.5
+  - 2.6
+gemfile:
+  - Gemfile.rails52
+  - Gemfile.rails6
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+    > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - "./cc-test-reporter before-build"
+script:
+  - bundle exec rake spec
+after_script:
+  - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+
 jobs:
+  exclude:
+    - rvm: 2.5
+      gemfile: Gemfile.rails6
   include:
-  - stage: test-2.5
-    rvm: 2.5
-    gemfile: Gemfile
-    script: bundle exec rake spec
-
-  - stage: test-2.6
-    rvm: 2.6
-    gemfile: Gemfile
-    before_script:
-    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
-      > ./cc-test-reporter
-    - chmod +x ./cc-test-reporter
-    - "./cc-test-reporter before-build"
-    script:
-    - bundle exec rake spec
-    after_script:
-    - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
-
-  - stage: test-rails6
-    rvm: 2.6
-    gemfile: Gemfile.rails6
-    script: bundle exec rake spec
-
   - stage: tag-new-release-if-applicable
     if: branch = main AND type != pull_request
     rvm: 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ addons:
 rvm:
   - 2.5
   - 2.6
+  - 2.7
 gemfile:
   - Gemfile.rails52
   - Gemfile.rails6
+  - Gemfile.rails61
+
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
     > ./cc-test-reporter
@@ -22,6 +25,8 @@ jobs:
   exclude:
     - rvm: 2.5
       gemfile: Gemfile.rails6
+    - rvm: 2.7
+      gemfile: Gemfile.rails52
   include:
   - stage: tag-new-release-if-applicable
     if: branch = main AND type != pull_request

--- a/Gemfile.rails52
+++ b/Gemfile.rails52
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'rails', '>= 5.2', '< 6.0'
+
+gemspec

--- a/Gemfile.rails6
+++ b/Gemfile.rails6
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-source 'https://ibdolphin.jfrog.io/ibdolphin/api/gems/gems-private/'
 
 gem 'rails', '>= 6.0', '< 6.1'
 

--- a/Gemfile.rails6
+++ b/Gemfile.rails6
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+source 'https://ibdolphin.jfrog.io/ibdolphin/api/gems/gems-private/'
+
+gem 'rails', '>= 6.0', '< 6.1'
+
+gemspec

--- a/Gemfile.rails61
+++ b/Gemfile.rails61
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'rails', '>= 6.1', '< 6.2'
+
+gemspec

--- a/atomic_cache.gemspec
+++ b/atomic_cache.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop', '~> 0.8.1'
 
   # Dependencies
-  spec.add_dependency 'activesupport', '>= 4.2', '< 6'
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'murmurhash3', '~> 0.1'
 end

--- a/atomic_cache.gemspec
+++ b/atomic_cache.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Dev dependencies
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'gems', '~> 1.0'
   spec.add_development_dependency 'git', '~> 1.3'
   spec.add_development_dependency 'github_changelog_generator', '>= 1.15.0.pre.rc'


### PR DESCRIPTION
Background
-----
Updates the Travis build configuration to also build against Rails 6, Rails 6.1, and Ruby 2.7.

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [ ] Backwards-incompatible changes called out in this PR
* [ ] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
