### PR TITLE
Class Macros & Inheritance

### DIFF
--- a/atomic_cache.gemspec
+++ b/atomic_cache.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'timecop', '~> 0.8.1'
+  spec.add_development_dependency 'pry'
 
   # Dependencies
   spec.add_dependency 'activesupport', '>= 4.2'

--- a/docs/MODEL_SETUP.md
+++ b/docs/MODEL_SETUP.md
@@ -29,3 +29,47 @@ class Foo < ActiveRecord::Base
   cache_version(5)
 end
 ```
+
+### Inheritance
+
+When either `force_cache_class` or `cache_version` are used, those values will always be preferred by classes which inherit from the class on which those macros exist. When macros are used on descendant classes, the "closet" value wins.
+
+#### Example #1
+The keys used by `Bar` will be prefixed with `custom:v5`, as it prefers both the 'custom' class name and version 5 from the parent.
+```ruby
+class Foo < ActiveRecord::Base
+  include AtomicCache::GlobalLMTCacheConcern
+  force_cache_class('custom')
+  cache_version(5)
+end
+
+class Bar < Foo
+end
+```
+
+#### Example #2
+The keys used by `Bar` will be prefixed with `bar:v5`, as the version 5 is taken from the parent, but the use of forcing on the child class result in the cache class of 'bar'.
+```ruby
+class Foo < ActiveRecord::Base
+  include AtomicCache::GlobalLMTCacheConcern
+  cache_version(5)
+end
+
+class Bar < Foo
+  force_cache_class('bar')
+end
+```
+
+#### Example #3
+The keys used by `Bar` will be still be prefixed with `bar:v5` for the same reasons as above.
+```ruby
+class Foo < ActiveRecord::Base
+  include AtomicCache::GlobalLMTCacheConcern
+  force_cache_class('custom')
+  cache_version(5)
+end
+
+class Bar < Foo
+  force_cache_class('bar')
+end
+```


### PR DESCRIPTION
Background
-----

This PR changes how the class macros (`force_cache_class` and `cache_version`) interact with inheritance. 

Consider the following scenarios. What would the correct cache prefix be?

Case 1:
```
class Foo
  include AtomicCache::GlobalLMTCacheConcern
  cache_version(6)
end
class Bar < Foo
  force_cache_class('asdf')
end
```

Case 2:
``
class Foo
  include AtomicCache::GlobalLMTCacheConcern
  force_cache_class('asdf')
end
class Bar < Foo
  cache_version(6)
end
```

This PR changes is so that the preference of values is: Local override > Parent override > default value. Previously the gem would not consider parent override values. Summarized below as...

**BEFORE:**
Case 1 = `asdf`
Case 2 = `bar:v6`

**AFTER:**
Case 1 = `asdf:v6`
Case 2 = `asdf:v6`

Version
-----
This change will not break the interface of existing code, but could possibly be considered backwards incompatible due to the key changing (assuming something relies on knowing what that value is). Since the gem is still in pre-release/pre-1.0 status though a minor version change will be used.

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs written and passing
* [ ] Backwards-incompatible changes called out in this PR
* [ ] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
