### PR TITLE
Mtf 753 more info on give up log

### DIFF
--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -148,7 +148,7 @@ module AtomicCache
       end
 
       metrics(:increment, 'wait.give-up')
-      log(:warn, "Giving up waiting. Exceeded max retries (#{max_retries}).")
+      log(:warn, "Giving up waiting. Exceeded max retries (#{max_retries}) for #{key}.")
       nil
     end
 

--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -148,7 +148,7 @@ module AtomicCache
       end
 
       metrics(:increment, 'wait.give-up')
-      log(:warn, "Giving up waiting. Exceeded max retries (#{max_retries}) for #{key}.")
+      log(:warn, "Giving up waiting. Exceeded max retries (#{max_retries}) for #{keyspace.root}.")
       nil
     end
 

--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -148,7 +148,7 @@ module AtomicCache
       end
 
       metrics(:increment, 'wait.give-up')
-      log(:warn, "Giving up waiting. Exceeded max retries (#{max_retries}) for #{keyspace.root}.")
+      log(:warn, "Giving up waiting. Exceeded max retries (#{max_retries}) for root #{keyspace.root}.")
       nil
     end
 

--- a/lib/atomic_cache/version.rb
+++ b/lib/atomic_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AtomicCache
-  VERSION = "0.5.4.rc1"
+  VERSION = "0.5.5.rc1"
 end


### PR DESCRIPTION
Background
-----

When warnings are triggered we dont want to dig into metrics to see which call site was triggered. Adding the keyspace root to the log should be enough to tell us the culprit. 

(See this thread for [additional context](https://ibotta.slack.com/archives/G38UXJ821/p1632167675048000), additional enhancement would be to enable APM)

Tasks
-----
* [x] [Code of Conduct](https://github.com/Ibotta/atomic_cache/blob/main/CODE_OF_CONDUCT.md) reviewed
* [x] Specs passing
* [ ] Backwards-incompatible changes called out in this PR (NA)
* [x] Increment the version file (`./lib/atomic_cache/version.rb`) when applicable
    * See [semver.org](https://semver.org/) for what segment to increment
