### PR TITLE
verions issues for ruby < 3.2, drop ruby 3.1 from test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,11 @@ name: ibotta/atomic_cache
 on:
   push:
     branches:
-    - "main"
+      - "main"
   pull_request:
 
-# This allows a subsequently queued workflow run to interrupt previous runs
-# concurrency:
-#   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
 
 permissions:
   contents: write
@@ -23,58 +22,55 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
         gemfile:
-        - Gemfile.rails61
-        - Gemfile.rails7
-        exclude:
-        - ruby: '3.0'
-          gemfile: Gemfile.rails7
+          - Gemfile.rails61
+          - Gemfile.rails7
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v7
-    - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        ruby-version: ${{ matrix.ruby }}
-    - name: Test
-      run: bundle exec rake spec
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+      - name: Test
+        run: bundle exec rake spec
 
   tag_new_release_if_applicable:
     needs:
-    - test
+      - test
     runs-on: ubuntu-latest
     if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request' }}
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v7
-    - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.4.9
-        bundler-cache: true
-    - name: Kickoff Release Pipeline
-      run: "bundle exec ./ci-helpers/gem_helper kickoff_release_pipeline"
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+      - name: Kickoff Release Pipeline
+        run: "bundle exec ./ci-helpers/gem_helper kickoff_release_pipeline"
 
   publish_gem_if_applicable:
     needs:
-    - test
-    - tag_new_release_if_applicable
+      - test
+      - tag_new_release_if_applicable
     runs-on: ubuntu-latest
     if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request' }}
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v7
-    - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.4.9
-        bundler-cache: true
-    - name: Publish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      run: |-
-        bundle exec ./ci-helpers/gem_helper publish
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+      - name: Publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |-
+          bundle exec ./ci-helpers/gem_helper publish

--- a/Gemfile.rails61
+++ b/Gemfile.rails61
@@ -2,7 +2,11 @@
 
 source "https://rubygems.org"
 
-gem 'rails', '>= 6.1', '< 6.2'
+gem 'rails', '>= 6.1', '< 7'
+
 gem 'bigdecimal'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.2')
+  gem 'i18n', '< 1.15'
+end
 
 gemspec

--- a/Gemfile.rails7
+++ b/Gemfile.rails7
@@ -2,6 +2,10 @@
 
 source "https://rubygems.org"
 
-gem 'rails', '>= 7.0'
+gem 'rails', '~> 7.0.0'
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.2')
+  gem 'i18n', '< 1.15'
+end
 
 gemspec


### PR DESCRIPTION
Background
-----

Fixes the matrix to make ruby 3.1 work with the i18n gem (minor version removed ruby < 3.1 support)

