### PR TITLE
fix: correct typos and copy-paste bugs in key management

### DIFF
--- a/lib/atomic_cache/atomic_cache_client.rb
+++ b/lib/atomic_cache/atomic_cache_client.rb
@@ -31,7 +31,7 @@ module AtomicCache
     #
     # @param keyspace [AtomicCache::Keyspace] the keyspace to fetch
     # @option options [Numeric] :generate_ttl_ms (30000) Max generate duration in ms
-    # @option options [Numeric] :max_retries (5) Max times to rety in waiting case
+    # @option options [Numeric] :max_retries (5) Max times to retry in waiting case
     # @option options [Numeric] :backoff_duration_ms (50) Duration in ms to wait between retries
     # @yield Generates a new value when cache is expired
     def fetch(keyspace, options={}, &blk)

--- a/lib/atomic_cache/key/keyspace.rb
+++ b/lib/atomic_cache/key/keyspace.rb
@@ -33,9 +33,9 @@ module AtomicCache
     # @param namespace [Array<Object>] segments to concat onto this keyspace
     # @return [AtomicCache::Keyspace] child keyspace
     def child(namespace)
-      throw ArgumentError.new("Prefix must be an Array but was #{namespace.class}") unless namespace.is_a?(Array)
-      joined_namespacees = @namespace.clone.concat(namespace)
-      self.class.new(namespace: joined_namespacees)
+      raise ArgumentError.new("Prefix must be an Array but was #{namespace.class}") unless namespace.is_a?(Array)
+      joined_namespaces = @namespace.clone.concat(namespace)
+      self.class.new(namespace: joined_namespaces)
     end
 
     # Get a string key for this keyspace, optionally suffixed by the given value

--- a/lib/atomic_cache/key/last_mod_time_key_manager.rb
+++ b/lib/atomic_cache/key/last_mod_time_key_manager.rb
@@ -18,7 +18,7 @@ module AtomicCache
       @timestamp_formatter = timestamp_formatter || DefaultConfig.instance.timestamp_formatter
 
       raise ArgumentError.new("`storage` required but none given") unless @storage.present?
-      raise ArgumentError.new("`root_keyspace` required but none given") unless @storage.present?
+      raise ArgumentError.new("`timestamp_keyspace` required but none given") unless @timestamp_keyspace.present?
     end
 
     # get the key at the given keyspace, suffixed by the current timestamp


### PR DESCRIPTION
## Summary

Fix 4 issues across 3 files:

- `atomic_cache_client.rb`: fix typo `rety` → `retry` in comment
- `last_mod_time_key_manager.rb`: fix copy-paste error in validation — was checking wrong variable (`@storage` instead of `@timestamp_keyspace`) and showing wrong field name (`root_keyspace` instead of `timestamp_keyspace`) in error message
- `keyspace.rb`: fix `throw` → `raise` for ArgumentError (Ruby `throw` is catch/throw control flow, not exception raising), fix variable name `joined_namespacees` → `joined_namespaces`

**Note:** The `throw` → `raise` and validation fixes are behavioral changes. The `throw` would silently unwind to a matching `catch` (or raise `UncaughtThrowError` if none exists) instead of properly raising an `ArgumentError`. The validation fix means the constructor will now correctly reject a missing `keyspace` argument instead of silently accepting it. Please review carefully.